### PR TITLE
Introduce ColorSupportLevel type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning][2].
 
 ## Unreleased
 
+### Changed
+
+- Introduce `ColorSupportLevel` type.
+  Accordingly, the signature of `mkChoku` is changed to
+  `mkChoku :: ColorSupportLevel -> Choku`.
+  
 ## [0.2.2][v0.2.2] (2024-01-26)
 
 ### Fixed

--- a/src/Choku/Common.js
+++ b/src/Choku/Common.js
@@ -4,8 +4,19 @@ export const _newChalk = function(level_) {
     return new Chalk({ level: level_ });
 };
 
-export const level = function(self) {
-    return self.level;
+export const _level = function(hasNoColors, hasBasicColors, has256Colors, has16mColors, self) {
+    switch (self.level) {
+        case 1:
+            return hasBasicColors;
+        case 2:
+            return has256Colors;
+        case 3:
+            return has16mColors;
+        // Trust that it IS 0 because it has already been validated:
+        // https://github.com/chalk/chalk/blob/72c742d4716b1f94bb24bbda86d96fbb247ca646/source/index.js#L24-L32
+        default:
+            return hasNoColors;
+    }
 };
 
 export const withChokuFlipped = function(self) {


### PR DESCRIPTION
Close #2

I'd like to leave https://github.com/m15a/purescript-choku/blob/a95e7c6ca9865227ac75cdc3bea58ec4a0ba5bae/src/Choku/Stdout.purs#L32-L41 as is since it may provide more information for debug use.